### PR TITLE
Add support for multiple examples per code object

### DIFF
--- a/features/yard-doctest.feature
+++ b/features/yard-doctest.feature
@@ -124,8 +124,12 @@ Feature: yard doctest
     When I run `bundle exec yard doctest`
     Then the output should contain:
       """
-      Expected: 2
-        Actual: "2"
+      --- expected
+      +++ actual
+      @@ -1 +1,2 @@
+      -2
+      +# encoding: US-ASCII
+      +"2"
       """
 
   Scenario: asserts exceptions

--- a/features/yard-doctest.feature
+++ b/features/yard-doctest.feature
@@ -494,6 +494,32 @@ Feature: yard doctest
     When I run `bundle exec yard doctest`
     Then the output should contain "2 runs, 2 assertions, 0 failures, 0 errors, 0 skips"
 
+  Scenario: supports test-name hooks for multiple examples on the same code object
+    Given a file named "doctest_helper.rb" with:
+      """
+      require 'app/app'
+
+      YARD::Doctest.before('#flag') do
+        @flag = true
+      end
+
+      YARD::Doctest.before('#flag@Second example for flag') do
+        @flag = false
+      end
+      """
+    And a file named "app/app.rb" with:
+      """
+      # @example
+      #   flag #=> true
+      # @example Second example for flag
+      #   flag #=> false
+      def flag
+        @flag
+      end
+      """
+    When I run `bundle exec yard doctest`
+    Then the output should contain "2 runs, 2 assertions, 0 failures, 0 errors, 0 skips"
+
   Scenario: can skip tests
     Given a file named "doctest_helper.rb" with:
       """


### PR DESCRIPTION
This PR adds support for writing specific before/after hooks when there are multiple examples per code object ([example from google-cloud-ruby](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/google-cloud-bigquery/v0.20.1/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L276-L312)) by increasing the detail in the identifier passed to `register_hooks`.

Some notes:

1. The new identifier is the [spec method name](https://github.com/seattlerb/minitest/blob/master/lib/minitest/spec.rb#L218) generated by Minitest::Spec. This makes it very simple to match hooks to failing tests, all you need to do is copy the name from the Minitest output.
1. Because hooks are matched by testing `include?` on the hook name, backwards-compatibility is maintained for less-specific hook names (all Cucumber tests pass.)
1. As was the case before, less-specific hook names will also be matched, so hook order is important.

I'm happy to make any edits/changes, just let me know!

/cc @blowmage