### PR TITLE
allow doctest_helper.rb in spec directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ Next, you'll need to create test helper, which will be required before each of y
 
 ```bash
 $ touch doctest_helper.rb
-# or if you don't want to have it in root
-$ touch support/doctest_helper.rb
+# or move it into either the `support` or `spec` directory
 ```
 
 ```ruby

--- a/features/yard-doctest.feature
+++ b/features/yard-doctest.feature
@@ -425,6 +425,7 @@ Feature: yard doctest
       | directory |
       | .         |
       | support   |
+      | spec      |
 
   Scenario: shares binding between asserts
     Given a file named "doctest_helper.rb" with:

--- a/lib/yard/doctest/example.rb
+++ b/lib/yard/doctest/example.rb
@@ -20,7 +20,7 @@ module YARD
         Class.new(this.class).class_eval do
           require 'minitest/autorun'
 
-          %w[. support].each do |dir|
+          %w[. support spec].each do |dir|
             require "#{dir}/doctest_helper" if File.exist?("#{dir}/doctest_helper.rb")
           end
 


### PR DESCRIPTION
Most of my projects already have a `spec` folder, but not a `support` folder. This cleans things up a bit, and it makes sense to move it in that folder anyway, as far as I'm concerned.

Let me know if this patch is acceptable, if not, I'm happy to keep using the forked version.