### PR TITLE
allow binding to local context

### DIFF
--- a/features/yard-doctest.feature
+++ b/features/yard-doctest.feature
@@ -595,3 +595,22 @@ Feature: yard doctest
       """
     When I run `bundle exec yard doctest`
     Then the output should contain "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips"
+
+    Scenario: allow binding to local context
+      Given a file named "doctest_helper.rb" with:
+        """
+        require 'app/app'
+        """
+      And a file named "app/app.rb" with:
+        """
+        class App
+          # @example
+          #   a, b = 1, 2
+          #   sum(a, b) #=> 3
+          def self.sum(one, two)
+            one + two
+          end
+        end
+        """
+      When I run `bundle exec yard doctest`
+      Then the output should contain "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips"


### PR DESCRIPTION
This change tries to find an existing class or module, and use that as the context for the example, instead of the default anonymous binding.

This makes it easier to write this:

```ruby
class App
  # @example
  #   a, b = 1, 2
  #   sum(a, b) #=> 3
  def self.sum(one, two)
    one + two
  end
end
```

instead of this:

```ruby
class App
  # @example
  #   a, b = 1, 2
  #   App.sum(a, b) #=> 3
  def self.sum(one, two)
    one + two
  end
end
```

In the above example the change is only small (`App.`), but I noticed that in larger projects it can become a bit cumbersome to constantly write `My::Module::App.sum` instead of just expecting the example to run in the context of the current object, and simply writing `sum`.

If you want, I can make this configurable.