### PR TITLE
Fix #12 - use assert_nil on expected nils to mitigate Minitest deprecation warning

### DIFF
--- a/features/yard-doctest.feature
+++ b/features/yard-doctest.feature
@@ -785,3 +785,26 @@ Feature: yard doctest
       """
       app/app.rb:4:in `foo'
       """
+  
+  Scenario: Expecting `nil` does not issue deprecation warning
+    
+    See https://github.com/p0deje/yard-doctest/issues/12
+    
+    Given a file named "doctest_helper.rb" with:
+      """
+      require 'lib/assert_nil'
+      """
+    And a file named "lib/assert_nil.rb" with:
+      """
+      # @example
+      #   foo #=> nil
+      def foo
+        nil
+      end
+      """
+    When I run `bundle exec yard doctest`
+    Then the exit status should be 0
+    And the output should not contain:
+      """
+      DEPRECATED
+      """

--- a/features/yard-doctest.feature
+++ b/features/yard-doctest.feature
@@ -198,6 +198,7 @@ Feature: yard doctest
       """
     When I run `bundle exec yard doctest`
     Then the output should contain "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips"
+    And the output should not contain "DEPRECATED"
     Examples:
       | value |
       | true  |
@@ -784,27 +785,4 @@ Feature: yard doctest
     And the output should contain:
       """
       app/app.rb:4:in `foo'
-      """
-  
-  Scenario: Expecting `nil` does not issue deprecation warning
-    
-    See https://github.com/p0deje/yard-doctest/issues/12
-    
-    Given a file named "doctest_helper.rb" with:
-      """
-      require 'lib/assert_nil'
-      """
-    And a file named "lib/assert_nil.rb" with:
-      """
-      # @example
-      #   foo #=> nil
-      def foo
-        nil
-      end
-      """
-    When I run `bundle exec yard doctest`
-    Then the exit status should be 0
-    And the output should not contain:
-      """
-      DEPRECATED
       """

--- a/lib/yard/doctest/example.rb
+++ b/lib/yard/doctest/example.rb
@@ -78,6 +78,8 @@ module YARD
           assert_equal("#<#{expected.class}: #{expected}>", "#<#{actual.class}: #{actual}>")
         elsif (error = only_one_is_error?(expected, actual))
           raise error
+        elsif expected.nil?
+          assert_nil(actual)
         else
           assert_equal(expected, actual)
         end


### PR DESCRIPTION
See details in #12 

Fix is two lines. Added a feature that fails before and passes after. Features all pass on my local (Ruby 2.3).