### PR TITLE
ensure procs work when tested

### DIFF
--- a/features/yard-doctest.feature
+++ b/features/yard-doctest.feature
@@ -786,3 +786,17 @@ Feature: yard doctest
       """
       app/app.rb:4:in `foo'
       """
+
+  Scenario: handles a proc successfully
+    Given a file named "doctest_helper.rb" with:
+      """
+      require 'app/app'
+      """
+    And a file named "app/app.rb" with:
+      """
+      # @example
+      #   MyClass.call #=> 1
+      MyClass = lambda { 1 }
+      """
+      When I run `bundle exec yard doctest`
+      Then the output should contain "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips"

--- a/lib/yard/doctest/example.rb
+++ b/lib/yard/doctest/example.rb
@@ -45,7 +45,7 @@ module YARD
               end
 
               global_constants = Object.constants
-              scope_constants = scope.constants if scope
+              scope_constants = scope.constants if scope && scope.respond_to?(:constants)
               this.asserts.each do |assert|
                 expected, actual = assert[:expected], assert[:actual]
                 if expected.empty?
@@ -55,7 +55,7 @@ module YARD
                 end
               end
               clear_extra_constants(Object, global_constants)
-              clear_extra_constants(scope, scope_constants) if scope
+              clear_extra_constants(scope, scope_constants) if scope && scope.respond_to?(:constants)
             end
           end
         end

--- a/lib/yard/doctest/version.rb
+++ b/lib/yard/doctest/version.rb
@@ -1,5 +1,5 @@
 module YARD
   module Doctest
-    VERSION = '0.1.16'
+    VERSION = '0.1.17'
   end
 end


### PR DESCRIPTION
Found this randomly trying to implement in my own project. lambdas/Procs don't expose a constants method and will break during test (but not anymore!)