### PR TITLE
allow rake task to be a dependency

### DIFF
--- a/lib/yard/doctest/rake.rb
+++ b/lib/yard/doctest/rake.rb
@@ -30,7 +30,7 @@ module YARD
         desc 'Run YARD doctests'
         task(name) do
           command = "yard doctest #{(doctest_opts << pattern).join(' ')}"
-          exit system(command)
+          abort unless system(command)
         end
       end
 


### PR DESCRIPTION
Before this change, you could not use `yard:doctest` as a dependency of another rake task, since it would unconditionally `exit` the process when complete.

That means the following will never run `rubocop`, nor any further dependent tasks. 

```ruby
task all_tests: %i[rspec yard:doctest rubocop]
``` 

After this change, `yard:doctest` exits _only_ if doctests were unsuccessful, allowing it be used as part of a rake task pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/p0deje/yard-doctest/17)
<!-- Reviewable:end -->
