### PR TITLE
Respect the Minitest convention for test directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ To do so, add yard-doctest as an automatically loaded plugin in your `.yardops`:
 --plugin yard-doctest
 ```
 
-Next, you'll need to create test helper, which will be required before each of your test. Think about it as `spec_helper.rb` in RSpec or `env.rb` in Cucumber. You should require everything necessary for your examples to run there.
+Next, you'll need to create test helper, which will be required before each of your test. Think about it as `spec_helper.rb` in RSpec, `test_helper.rb` in Minitest, or `env.rb` in Cucumber. You should require everything necessary for your examples to run there.
 
 ```bash
 $ touch doctest_helper.rb
-# or move it into either the `support` or `spec` directory
+# or move it into the `support`, `spec`, or `test` directory
 ```
 
 ```ruby

--- a/features/yard-doctest.feature
+++ b/features/yard-doctest.feature
@@ -462,6 +462,7 @@ Feature: yard doctest
       | .         |
       | support   |
       | spec      |
+      | test      |
 
   Scenario: shares binding between asserts
     Given a file named "doctest_helper.rb" with:

--- a/lib/yard/doctest/example.rb
+++ b/lib/yard/doctest/example.rb
@@ -20,7 +20,7 @@ module YARD
         Class.new(this.class).class_eval do
           require 'minitest/autorun'
 
-          %w[. support spec].each do |dir|
+          %w[. support spec test].each do |dir|
             require "#{dir}/doctest_helper" if File.exist?("#{dir}/doctest_helper.rb")
           end
 


### PR DESCRIPTION
Currently, when you use this gem with RSpec, you can have all test-related code segregated to the `spec/` folder since it looks for `spec/doctest_helper.rb`. This is not true if you use Minitest since it doesn't look in the conventional `test/` directory that Minitest uses.

To make the gem work well with Minitest as well, this change allows the helper file to live in the `test/` directory.