### PR TITLE
Allow SimpleCov to correctly collect coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :test do
+  gem 'simplecov'
+end

--- a/features/yard-doctest.feature
+++ b/features/yard-doctest.feature
@@ -822,3 +822,26 @@ Feature: yard doctest
       """
       When I run `bundle exec yard doctest`
       Then the output should contain "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips"
+
+  Scenario: properly supports calculating coverage
+    Given a file named "doctest_helper.rb" with:
+      """
+      require 'simplecov'
+
+      SimpleCov.start
+
+      require 'app/app'
+      """
+    And a file named "app/app.rb" with:
+      """
+      # @example
+      #   MyClass.call #=> 1
+      class MyClass
+        def self.call
+          1
+        end
+      end
+      """
+    When I run `bundle exec yard doctest`
+    Then the output should contain "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips"
+    And the output should contain "3 / 3 LOC (100.0%) covered."

--- a/lib/yard/cli/doctest.rb
+++ b/lib/yard/cli/doctest.rb
@@ -22,6 +22,7 @@ module YARD
         add_pwd_to_path
 
         generate_tests(examples)
+        run_tests
       end
 
       private
@@ -84,6 +85,10 @@ module YARD
           spec.asserts = asserts
           spec.generate
         end
+      end
+
+      def run_tests
+        Minitest.autorun
       end
 
       def add_pwd_to_path

--- a/lib/yard/doctest/example.rb
+++ b/lib/yard/doctest/example.rb
@@ -18,8 +18,6 @@ module YARD
         this = self
 
         Class.new(this.class).class_eval do
-          require 'minitest/autorun'
-
           %w[. support spec].each do |dir|
             require "#{dir}/doctest_helper" if File.exist?("#{dir}/doctest_helper.rb")
           end


### PR DESCRIPTION
Because the original implementation required `minitest/autorun` in front of every test instance, Minitest eagerly ran each test as it was defined, before the other tests were run. This causes modern versions of SimpleCov to calculate coverage too early in the process.

This change explicitly runs Minitest after compiling every example. This is more in-line with how normal test suites run so SimpleCov works like normal as long as you set it up in the `doctest_helper.rb` file.